### PR TITLE
Initial audio ducking implementation

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/MainActivity.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/MainActivity.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.launch
 import org.stypox.dicio.di.SttInputDeviceWrapper
 import org.stypox.dicio.di.WakeDeviceWrapper
 import org.stypox.dicio.eval.SkillEvaluator
+import org.stypox.dicio.io.audio.AudioFocusManager
 import org.stypox.dicio.io.wake.WakeService
 import org.stypox.dicio.io.wake.WakeState.Loaded
 import org.stypox.dicio.io.wake.WakeState.Loading
@@ -45,6 +46,8 @@ class MainActivity : BaseActivity() {
     lateinit var sttInputDevice: SttInputDeviceWrapper
     @Inject
     lateinit var wakeDevice: WakeDeviceWrapper
+    @Inject
+    lateinit var audioFocusManager: AudioFocusManager
 
     private var sttPermissionJob: Job? = null
     private var wakeServiceJob: Job? = null
@@ -98,6 +101,9 @@ class MainActivity : BaseActivity() {
     override fun onStop() {
         super.onStop()
         isInForeground -= 1
+
+        // Release audio focus when the app goes to background
+        audioFocusManager.releaseFocus()
 
         // once the activity is swiped away from the lock screen (or put in the background in any
         // other way), we don't want to show it on the lock screen anymore

--- a/app/src/main/kotlin/org/stypox/dicio/di/SpeechOutputDeviceWrapper.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SpeechOutputDeviceWrapper.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.dicio.skill.context.SpeechOutputDevice
+import org.stypox.dicio.io.audio.AudioFocusManager
 import org.stypox.dicio.io.speech.AndroidTtsSpeechDevice
 import org.stypox.dicio.io.speech.NothingSpeechDevice
 import org.stypox.dicio.io.speech.SnackbarSpeechDevice
@@ -29,6 +30,7 @@ class SpeechOutputDeviceWrapper @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val dataStore: DataStore<UserSettings>,
     private val localeManager: LocaleManager,
+    private val audioFocusManager: AudioFocusManager,
     // this is always instantiated, but will do nothing if
     // it is not the speech device chosen by the user
     private val snackbarSpeechDevice: SnackbarSpeechDevice,
@@ -54,7 +56,7 @@ class SpeechOutputDeviceWrapper @Inject constructor(
                         null,
                         UNRECOGNIZED,
                         SPEECH_OUTPUT_DEVICE_UNSET,
-                        SPEECH_OUTPUT_DEVICE_ANDROID_TTS -> AndroidTtsSpeechDevice(context, locale)
+                        SPEECH_OUTPUT_DEVICE_ANDROID_TTS -> AndroidTtsSpeechDevice(context, locale, audioFocusManager)
                         SPEECH_OUTPUT_DEVICE_NOTHING -> NothingSpeechDevice()
                         SPEECH_OUTPUT_DEVICE_TOAST -> ToastSpeechDevice(context)
                         SPEECH_OUTPUT_DEVICE_SNACKBAR -> snackbarSpeechDevice

--- a/app/src/main/kotlin/org/stypox/dicio/di/SttInputDeviceWrapper.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SttInputDeviceWrapper.kt
@@ -3,6 +3,7 @@ package org.stypox.dicio.di
 import android.content.Context
 import android.media.AudioAttributes
 import android.media.MediaPlayer
+import android.os.Build
 import androidx.datastore.core.DataStore
 import dagger.Module
 import dagger.Provides
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import org.stypox.dicio.R
+import org.stypox.dicio.io.audio.AudioFocusManager
 import org.stypox.dicio.io.input.InputEvent
 import org.stypox.dicio.io.input.SttInputDevice
 import org.stypox.dicio.io.input.SttState
@@ -53,6 +55,7 @@ class SttInputDeviceWrapperImpl(
     private val localeManager: LocaleManager,
     private val okHttpClient: OkHttpClient,
     private val activityForResultManager: ActivityForResultManager,
+    private val audioFocusManager: AudioFocusManager,
 ) : SttInputDeviceWrapper {
     private val scope = CoroutineScope(Dispatchers.Default)
 
@@ -102,7 +105,7 @@ class SttInputDeviceWrapperImpl(
         return when (setting) {
             UNRECOGNIZED,
             INPUT_DEVICE_UNSET,
-            INPUT_DEVICE_VOSK -> VoskInputDevice(appContext, okHttpClient, localeManager)
+            INPUT_DEVICE_VOSK -> VoskInputDevice(appContext, okHttpClient, localeManager, audioFocusManager)
             INPUT_DEVICE_EXTERNAL_POPUP ->
                 ExternalPopupInputDevice(appContext, activityForResultManager, localeManager)
             INPUT_DEVICE_NOTHING -> null
@@ -120,8 +123,14 @@ class SttInputDeviceWrapperImpl(
                 newSttInputDevice.uiState.collect {
                     _uiState.emit(it)
                     if (it == SttState.Listening) {
+                        // Request audio focus FIRST to duck background audio immediately
+                        // This will be maintained through TTS and released by AndroidTtsSpeechDevice
+                        audioFocusManager.requestFocus()
+                        // Play the listening sound after requesting focus
                         playSound(R.raw.listening_sound)
                     }
+                    // Note: We don't release audio focus here when STT stops
+                    // The focus is maintained through TTS and released by AndroidTtsSpeechDevice
                 }
             }
         }
@@ -141,6 +150,17 @@ class SttInputDeviceWrapperImpl(
             )
             .build()
         val mediaPlayer = MediaPlayer.create(appContext, resid, attributes, 0)
+        // Disable automatic audio focus handling by MediaPlayer so it doesn't interfere
+        // with our manual audio focus management
+        mediaPlayer.setAudioAttributes(attributes)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // On API 26+, explicitly disable MediaPlayer's automatic focus handling
+            mediaPlayer.setAudioAttributes(
+                AudioAttributes.Builder(attributes)
+                    .setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED)
+                    .build()
+            )
+        }
         mediaPlayer.setVolume(0.75f, 0.75f)
         mediaPlayer.start()
     }
@@ -162,9 +182,14 @@ class SttInputDeviceWrapperImpl(
 
     override fun stopListening() {
         sttInputDevice?.stopListening()
+        // Release audio focus when user manually stops listening
+        // (e.g., by clicking the mic button again while listening)
+        audioFocusManager.releaseFocus()
     }
 
     override fun onClick(eventListener: (InputEvent) -> Unit) {
+        // Audio focus is requested when state becomes Listening in restartUiStateJob()
+        // This works for both mic button clicks and hotword activation
         sttInputDevice?.onClick(wrapEventListener(eventListener))
     }
 
@@ -184,9 +209,10 @@ class SttInputDeviceWrapperModule {
         localeManager: LocaleManager,
         okHttpClient: OkHttpClient,
         activityForResultManager: ActivityForResultManager,
+        audioFocusManager: AudioFocusManager,
     ): SttInputDeviceWrapper {
         return SttInputDeviceWrapperImpl(
-            appContext, dataStore, localeManager, okHttpClient, activityForResultManager
+            appContext, dataStore, localeManager, okHttpClient, activityForResultManager, audioFocusManager
         )
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/eval/SkillEvaluator.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/eval/SkillEvaluator.kt
@@ -16,6 +16,7 @@ import org.dicio.skill.skill.Permission
 import org.dicio.skill.skill.SkillOutput
 import org.stypox.dicio.di.SkillContextInternal
 import org.stypox.dicio.di.SttInputDeviceWrapper
+import org.stypox.dicio.io.audio.AudioFocusManager
 import org.stypox.dicio.io.graphical.ErrorSkillOutput
 import org.stypox.dicio.io.graphical.MissingPermissionsSkillOutput
 import org.stypox.dicio.io.input.InputEvent
@@ -37,6 +38,7 @@ class SkillEvaluatorImpl(
     private val skillContext: SkillContextInternal,
     private val skillHandler: SkillHandler,
     private val sttInputDevice: SttInputDeviceWrapper,
+    private val audioFocusManager: AudioFocusManager,
 ) : SkillEvaluator {
 
     private val scope = CoroutineScope(Dispatchers.Default)
@@ -64,6 +66,8 @@ class SkillEvaluatorImpl(
     private suspend fun suspendProcessInputEvent(event: InputEvent) {
         when (event) {
             is InputEvent.Error -> {
+                // Release audio focus on error to restore background audio
+                audioFocusManager.releaseFocus()
                 addErrorInteractionFromPending(event.throwable)
             }
             is InputEvent.Final -> {
@@ -77,6 +81,8 @@ class SkillEvaluatorImpl(
                 evaluateMatchingSkill(event.utterances.map { it.first })
             }
             InputEvent.None -> {
+                // Don't release audio focus here - it will be released by TTS when done,
+                // or by the error handler if no TTS occurs
                 _state.value = _state.value.copy(pendingQuestion = null)
             }
             is InputEvent.Partial -> {
@@ -102,6 +108,8 @@ class SkillEvaluatorImpl(
                 }
             } ?: Pair(utterances[0], skillRanker.getFallbackSkill(skillContext, utterances[0]))
         } catch (throwable: Throwable) {
+            // Release audio focus on error to restore background audio
+            audioFocusManager.releaseFocus()
             addErrorInteractionFromPending(throwable)
             return
         }
@@ -167,6 +175,8 @@ class SkillEvaluatorImpl(
             }
 
         } catch (throwable: Throwable) {
+            // Release audio focus on error to restore background audio
+            audioFocusManager.releaseFocus()
             addErrorInteractionFromPending(throwable)
             return
         }
@@ -219,7 +229,8 @@ class SkillEvaluatorModule {
         skillContext: SkillContextInternal,
         skillHandler: SkillHandler,
         sttInputDevice: SttInputDeviceWrapper,
+        audioFocusManager: AudioFocusManager,
     ): SkillEvaluator {
-        return SkillEvaluatorImpl(skillContext, skillHandler, sttInputDevice)
+        return SkillEvaluatorImpl(skillContext, skillHandler, sttInputDevice, audioFocusManager)
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/io/audio/AudioFocusManager.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/audio/AudioFocusManager.kt
@@ -1,0 +1,120 @@
+package org.stypox.dicio.io.audio
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Manages audio focus for the voice assistant to duck other audio playback during interactions.
+ * Requests audio focus when STT starts listening and maintains it through TTS playback,
+ * releasing it only when the entire interaction is complete.
+ */
+@Singleton
+class AudioFocusManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private var focusRequest: AudioFocusRequest? = null
+    private var hasFocus = false
+    
+    // Required listener - Android needs this even for transient focus
+    private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+        Log.v(TAG, "Audio focus changed: $focusChange")
+        when (focusChange) {
+            AudioManager.AUDIOFOCUS_LOSS,
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+                // Another app took focus, we lost it
+                hasFocus = false
+            }
+        }
+    }
+
+    /**
+     * Requests audio focus to duck other audio. This should be called when STT starts listening.
+     * Uses AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK to allow other audio to continue at reduced volume.
+     */
+    @Synchronized
+    fun requestFocus() {
+        if (hasFocus) {
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val focusReq = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_ASSISTANT)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build()
+                )
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .setWillPauseWhenDucked(false)
+                .setAcceptsDelayedFocusGain(false)
+                .build()
+
+            focusRequest = focusReq
+            val result = audioManager.requestAudioFocus(focusReq)
+            hasFocus = (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
+            
+            if (!hasFocus) {
+                Log.w(TAG, "Audio focus request failed with result: $result")
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            val result = audioManager.requestAudioFocus(
+                audioFocusChangeListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
+            )
+            hasFocus = (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
+            
+            if (!hasFocus) {
+                Log.w(TAG, "Audio focus request failed (legacy) with result: $result")
+            }
+        }
+    }
+
+    /**
+     * Releases audio focus, allowing other audio to return to normal volume.
+     * This should be called when TTS finishes or the interaction is canceled.
+     */
+    @Synchronized
+    fun releaseFocus() {
+        if (!hasFocus) {
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            focusRequest?.let { 
+                audioManager.abandonAudioFocusRequest(it)
+            }
+            focusRequest = null
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(audioFocusChangeListener)
+        }
+        hasFocus = false
+    }
+
+    /**
+     * Called when TTS starts speaking to ensure audio focus is maintained.
+     * This is a safety check in case focus was somehow lost between STT and TTS.
+     */
+    @Synchronized
+    fun onTtsStarted() {
+        if (!hasFocus) {
+            Log.d(TAG, "TTS started without audio focus, requesting now")
+            requestFocus()
+        }
+    }
+
+    companion object {
+        private val TAG = AudioFocusManager::class.simpleName
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/io/input/vosk/VoskInputDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/input/vosk/VoskInputDevice.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import org.stypox.dicio.BuildConfig
 import org.stypox.dicio.di.LocaleManager
+import org.stypox.dicio.io.audio.AudioFocusManager
 import org.stypox.dicio.io.input.InputEvent
 import org.stypox.dicio.io.input.SttInputDevice
 import org.stypox.dicio.io.input.SttState
@@ -68,6 +69,7 @@ class VoskInputDevice(
     @ApplicationContext appContext: Context,
     private val okHttpClient: OkHttpClient,
     localeManager: LocaleManager,
+    private val audioFocusManager: AudioFocusManager,
 ) : SttInputDevice {
 
     private val _state: MutableStateFlow<VoskState>
@@ -434,6 +436,7 @@ class VoskInputDevice(
     ) {
         _state.value = Loaded(speechService)
         speechService.stop()
+        audioFocusManager.releaseFocus()
         if (sendNoneEvent) {
             eventListener(InputEvent.None)
         }

--- a/app/src/main/kotlin/org/stypox/dicio/io/speech/AndroidTtsSpeechDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/speech/AndroidTtsSpeechDevice.kt
@@ -8,9 +8,14 @@ import android.widget.Toast
 import androidx.annotation.StringRes
 import org.dicio.skill.context.SpeechOutputDevice
 import org.stypox.dicio.R
+import org.stypox.dicio.io.audio.AudioFocusManager
 import java.util.Locale
 
-class AndroidTtsSpeechDevice(private var context: Context, locale: Locale) : SpeechOutputDevice {
+class AndroidTtsSpeechDevice(
+    private var context: Context,
+    locale: Locale,
+    private val audioFocusManager: AudioFocusManager
+) : SpeechOutputDevice {
     private var textToSpeech: TextToSpeech? = null
     private var initializedCorrectly = false
     private val runnablesWhenFinished: MutableList<Runnable> = ArrayList()
@@ -25,9 +30,14 @@ class AndroidTtsSpeechDevice(private var context: Context, locale: Locale) : Spe
                         initializedCorrectly = true
                         setOnUtteranceProgressListener(object :
                             UtteranceProgressListener() {
-                            override fun onStart(utteranceId: String) {}
+                            override fun onStart(utteranceId: String) {
+                                // Ensure audio focus is maintained while TTS is speaking
+                                audioFocusManager.onTtsStarted()
+                            }
                             override fun onDone(utteranceId: String) {
                                 if ("dicio_$lastUtteranceId" == utteranceId) {
+                                    // Release audio focus when the last utterance finishes
+                                    audioFocusManager.releaseFocus()
                                     // run only when the last enqueued utterance is finished
                                     for (runnable in runnablesWhenFinished) {
                                         runnable.run()
@@ -39,6 +49,8 @@ class AndroidTtsSpeechDevice(private var context: Context, locale: Locale) : Spe
                             @Suppress("OVERRIDE_DEPRECATION")
                             @Deprecated("")
                             override fun onError(utteranceId: String) {
+                                // Release audio focus on error
+                                audioFocusManager.releaseFocus()
                             }
                         })
                     } else {
@@ -67,6 +79,9 @@ class AndroidTtsSpeechDevice(private var context: Context, locale: Locale) : Spe
 
     override fun stopSpeaking() {
         textToSpeech?.stop()
+        // Don't release audio focus here - it gets called when STT starts listening
+        // to interrupt any ongoing TTS, but we want to maintain focus through the interaction.
+        // Focus will be released when TTS finishes naturally in onDone() or on cleanup()
     }
 
     override val isSpeaking: Boolean
@@ -85,6 +100,8 @@ class AndroidTtsSpeechDevice(private var context: Context, locale: Locale) : Spe
             shutdown()
             textToSpeech = null
         }
+        // Release audio focus on cleanup
+        audioFocusManager.releaseFocus()
     }
 
     private fun handleInitializationError(@StringRes errorString: Int) {


### PR DESCRIPTION
First initial implementation of audio ducking via AudioFocusManager. Looking for feedback on how it is structured and functions.

This functions through AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK which will lower any background audio during the user's interaction with Dicio. Audio ducking starts in SttInputDeviceWrapper when it detects a listening state and is held until TTS finishes in AndroidTtsSpeechDevice.onDone().

I've added some fallback releases in VoskInputDevice.stopListening() (when the user taps the mic button to cancel an interaction), MainActivity.onStop() (when the user leaves the app), and when a skill errors out.

I believe this covers all cases but could definitely use some help testing this implementation. 

I've merged this into my test build - https://github.com/tylxr59/dicio-android/tree/tylxrs-build

Resolves https://github.com/Stypox/dicio-android/issues/363