### PR TITLE
fix(theme): make AppTheme respect dark mode to avoid splash flash

### DIFF
--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,5 @@
+<resources>
+
+    <style name="AppTheme" parent="android:Theme.Material.NoActionBar" />
+
+</resources>


### PR DESCRIPTION
Fixes #413

`AppTheme` (the app's `android:theme`, so also the pre-content window
background shown on cold launch) was hardcoded to
`android:Theme.Material.Light.NoActionBar` with no dark counterpart,
causing a bright white flash on cold launch even on a dark-themed
device in a dark environment.

Adds a `values-night` variant of `AppTheme` parented on
`android:Theme.Material.NoActionBar`, so the launch window background
follows system dark mode like the rest of the app already does. No new
dependency, no code change — just the standard Android
resource-qualifier pattern.

## Test plan
- [x] Built and ran on a real emulator (Pixel 7, Android 15).
- [x] Before/after on-device comparison with dark mode forced via
      `adb shell cmd uimode night yes`: before the fix, cold launch
      shows a bright near-white background; after, it's dark grey
      matching the rest of the app.
- [x] `:app:assembleDebug` succeeds with the new resource file.